### PR TITLE
Fixed left and right motor can naming conventions

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -27,8 +27,8 @@ public class RobotMap {
 
   public static final class mapChargerTreads {
 
-    public static final int LEFT_MOTOR_CAN = 8;
-    public static final int RIGHT_MOTOR_CAN = 9;
+    public static final int TREADS_LEFT_MOTOR_CAN = 8;
+    public static final int TREADS_RIGHT_MOTOR_CAN = 9;
   }
 
   public static final class mapControllers {
@@ -41,8 +41,8 @@ public class RobotMap {
 
   public static final class mapIntake {
     public static final I2C.Port COLOR_SENSOR_I2C = I2C.Port.kMXP;
-    public static final int LEFT_MOTOR_CAN = 11;
-    public static final int RIGHT_MOTOR_CAN = 12;
+    public static final int INTAKE_LEFT_MOTOR_CAN = 11;
+    public static final int INTAKE_RIGHT_MOTOR_CAN = 12;
 
     public static final int LIMIT_SWITCH_DIO = 13;
   }

--- a/src/main/java/frc/robot/subsystems/ChargerTreads.java
+++ b/src/main/java/frc/robot/subsystems/ChargerTreads.java
@@ -18,8 +18,8 @@ public class ChargerTreads extends SubsystemBase {
   SN_CANSparkMax rightMotor;
 
   public ChargerTreads() {
-    leftMotor = new SN_CANSparkMax(mapChargerTreads.LEFT_MOTOR_CAN);
-    rightMotor = new SN_CANSparkMax(mapChargerTreads.RIGHT_MOTOR_CAN);
+    leftMotor = new SN_CANSparkMax(mapChargerTreads.TREADS_LEFT_MOTOR_CAN);
+    rightMotor = new SN_CANSparkMax(mapChargerTreads.TREADS_RIGHT_MOTOR_CAN);
 
     configure();
   }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -32,8 +32,8 @@ public class Intake extends SubsystemBase {
   Color cubeColor;
 
   public Intake() {
-    leftMotor = new SN_CANSparkMax(mapIntake.LEFT_MOTOR_CAN);
-    rightMotor = new SN_CANSparkMax(mapIntake.RIGHT_MOTOR_CAN);
+    leftMotor = new SN_CANSparkMax(mapIntake.INTAKE_LEFT_MOTOR_CAN);
+    rightMotor = new SN_CANSparkMax(mapIntake.INTAKE_RIGHT_MOTOR_CAN);
 
     colorSensor = new ColorSensorV3(mapIntake.COLOR_SENSOR_I2C);
     colorMatcher = new ColorMatch();


### PR DESCRIPTION
Left and right motor cans for intake and treads were undescriptive, so I added their subsystem into the names.
Closes #108 