### PR TITLE
swerve drivetrain fixes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -85,7 +85,7 @@ public final class Constants {
       mapDrivetrain.FRONT_LEFT_DRIVE_CAN,
       mapDrivetrain.FRONT_LEFT_STEER_CAN,
       mapDrivetrain.FRONT_LEFT_ABSOLUTE_ENCODER_CAN,
-      70.927734, // absolute encoder offset
+      250.927734, // absolute encoder offset
       new Translation2d(
           WHEELBASE / 2.0,
           TRACK_WIDTH / 2.0),
@@ -95,7 +95,7 @@ public final class Constants {
       mapDrivetrain.FRONT_RIGHT_DRIVE_CAN,
       mapDrivetrain.FRONT_RIGHT_STEER_CAN,
       mapDrivetrain.FRONT_RIGHT_ABSOLUTE_ENCODER_CAN,
-      24.433594, // absolute encoder offset
+      204.433594, // absolute encoder offset
       new Translation2d(
           WHEELBASE / 2.0,
           -TRACK_WIDTH / 2.0),
@@ -105,7 +105,7 @@ public final class Constants {
       mapDrivetrain.BACK_LEFT_DRIVE_CAN,
       mapDrivetrain.BACK_LEFT_STEER_CAN,
       mapDrivetrain.BACK_LEFT_ABSOLUTE_ENCODER_CAN,
-      331.787109, // absolute encoder offset
+      151.787109, // absolute encoder offset
       new Translation2d(
           -WHEELBASE / 2.0,
           TRACK_WIDTH / 2.0),
@@ -115,7 +115,7 @@ public final class Constants {
       mapDrivetrain.BACK_RIGHT_DRIVE_CAN,
       mapDrivetrain.BACK_RIGHT_STEER_CAN,
       mapDrivetrain.BACK_RIGHT_ABSOLUTE_ENCODER_CAN,
-      66.005859, // absolute encoder offset
+      246.005859, // absolute encoder offset
       new Translation2d(
           -WHEELBASE / 2.0,
           -TRACK_WIDTH / 2.0),

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -70,6 +70,11 @@ public class RobotContainer {
         .onTrue(Commands.runOnce(
             () -> subDrivetrain.resetPose(new Pose2d())));
 
+    // while true do robot oriented, default to field oriented
+    conDriver.btn_LBump
+        .whileTrue(Commands.runOnce(() -> subDrivetrain.setRobotRelative()))
+        .onFalse(Commands.runOnce(() -> subDrivetrain.setFieldRelative()));
+
     // Operator
 
     // Set the arm to a preset position (example bind, may not be necessary for comp

--- a/src/main/java/frc/robot/SN_SwerveModule.java
+++ b/src/main/java/frc/robot/SN_SwerveModule.java
@@ -197,19 +197,14 @@ public class SN_SwerveModule {
   }
 
   /**
-   * Get the drive motor encoder count
-   * 
-   * @return Drive motor encoder count
-   */
-  public double getDriveEncoder() {
-    return -driveMotor.getSelectedSensorPosition();
-  }
-
-  /**
    * Reset the drive motor encoder count to 0.
    */
   public void resetDriveEncoderCount() {
     driveMotor.setSelectedSensorPosition(0);
+  }
+
+  public double getDriveMotorOutputPercent() {
+    return driveMotor.getMotorOutputPercent();
   }
 
   /**
@@ -242,7 +237,7 @@ public class SN_SwerveModule {
   public SwerveModulePosition getPosition() {
 
     double distance = SN_Math.falconToMeters(
-        getDriveEncoder(),
+        driveMotor.getSelectedSensorPosition(),
         Constants.WHEEL_CIRCUMFERENCE,
         Constants.DRIVE_GEAR_RATIO);
 

--- a/src/main/java/frc/robot/commands/Drive.java
+++ b/src/main/java/frc/robot/commands/Drive.java
@@ -55,9 +55,9 @@ public class Drive extends CommandBase {
   @Override
   public void execute() {
 
-    xVelocity = -conDriver.getAxisLSY();
-    yVelocity = conDriver.getAxisLSX();
-    rVelocity = conDriver.getAxisRSX();
+    xVelocity = conDriver.getAxisLSY();
+    yVelocity = -conDriver.getAxisLSX();
+    rVelocity = -conDriver.getAxisRSX();
     translationScalar = conDriver.getAxisRT();
 
     xVelocity = MathUtil.applyDeadband(xVelocity, constControllers.DRIVER_LEFT_STICK_Y_DEADBAND);

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -63,6 +63,13 @@ public class Drivetrain extends SubsystemBase {
   public void configure() {
     for (SN_SwerveModule mod : modules) {
       mod.configure();
+    }
+
+    // (i think) since the drive motor inversions takes a meanful amount of time, it
+    // eats the instruction to reset the encoder counts. so we just wait a second
+    // after inverting the modules to reset the steer motor encoders to absolute
+    Timer.delay(1.0);
+    for (SN_SwerveModule mod : modules) {
       mod.resetSteerMotorEncodersToAbsolute();
     }
   }
@@ -115,6 +122,20 @@ public class Drivetrain extends SubsystemBase {
     for (SN_SwerveModule mod : modules) {
       mod.neutralDriveOutput();
     }
+  }
+
+  /**
+   * Set the drive method to use field relative drive controls
+   */
+  public void setFieldRelative() {
+    isFieldRelative = true;
+  }
+
+  /**
+   * Set the drive method to use robot relative drive controls
+   */
+  public void setRobotRelative() {
+    isFieldRelative = false;
   }
 
   /**
@@ -207,14 +228,14 @@ public class Drivetrain extends SubsystemBase {
             Units.metersToFeet(mod.getState().speedMetersPerSecond));
         SmartDashboard.putNumber("Module " + mod.moduleNumber + " Distance",
             Units.metersToFeet(mod.getPosition().distanceMeters));
-        SmartDashboard.putNumber("Module " + mod.moduleNumber + " Drive Encoder Counts",
-            mod.getDriveEncoder());
         SmartDashboard.putNumber("Module " + mod.moduleNumber + " Angle",
             mod.getState().angle.getDegrees());
         SmartDashboard.putNumber("Module " + mod.moduleNumber + " Absolute Encoder Angle",
             mod.getAbsoluteEncoder().getDegrees());
         SmartDashboard.putNumber("Module " + mod.moduleNumber + " Raw Absolute Encoder Angle",
             mod.getRawAbsoluteEncoder());
+        SmartDashboard.putNumber("Module " + mod.moduleNumber + " Drive Output Percent",
+            mod.getDriveMotorOutputPercent());
       }
     }
   }


### PR DESCRIPTION
* added 180 degrees to absolute encoder offsets
* uninverted drive encoder
* inverted joysticks
* debug output for swerve drive motor output percent
* button that, while true, sets the drivetrain to use robot relative driving
  * on false sets back to field relative