### PR TITLE
replace pose estimation rotation with raw navx yaw

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,7 +8,6 @@ import com.frcteam3255.joystick.SN_XboxController;
 import com.frcteam3255.joystick.SN_SwitchboardStick;
 
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.LEDs;
@@ -79,7 +78,7 @@ public class RobotContainer {
     // higher level
     conDriver.btn_A
         .onTrue(Commands.runOnce(
-            () -> subDrivetrain.resetPose(new Pose2d(subDrivetrain.getPose().getTranslation(), new Rotation2d(0)))));
+            () -> subDrivetrain.resetRotation()));
     conDriver.btn_B
         .onTrue(Commands.runOnce(
             () -> subDrivetrain.resetPose(new Pose2d())));

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -146,7 +146,7 @@ public class Drivetrain extends SubsystemBase {
         Units.degreesToRadians(prefDrivetrain.teleThetaMaxSpeed.getValue()),
         Units.degreesToRadians(prefDrivetrain.teleThetaMaxAccel.getValue())));
     thetaPID.setTolerance(Units.inchesToMeters(prefDrivetrain.teleThetaTolerance.getValue()));
-    thetaPID.reset(getPose().getRotation().getRadians());
+    thetaPID.reset(getRotation().getRadians());
     thetaPID.enableContinuousInput(-Math.PI, Math.PI);
 
     // (i think) since the drive motor inversions takes a meanful amount of time, it
@@ -212,7 +212,7 @@ public class Drivetrain extends SubsystemBase {
     // calculate the angle setpoint based off where we are now.
     // note that this will not just be the rotation we passed in, it will be some
     // position inbetween.
-    double angleSetpoint = thetaPID.calculate(getPose().getRotation().getRadians());
+    double angleSetpoint = thetaPID.calculate(getRotation().getRadians());
 
     // create a new velocity Pose2d with the same translation as the on that was
     // passed in, but with the output of the theta PID controller for rotation.
@@ -237,7 +237,7 @@ public class Drivetrain extends SubsystemBase {
           velocity.getX(),
           velocity.getY(),
           velocity.getRotation().getRadians(),
-          getPose().getRotation());
+          getRotation());
     } else {
       chassisSpeeds = new ChassisSpeeds(
           velocity.getX(),
@@ -306,7 +306,7 @@ public class Drivetrain extends SubsystemBase {
   public void resetPID() {
     xPID.reset(getPose().getX());
     yPID.reset(getPose().getY());
-    thetaPID.reset(getPose().getRotation().getRadians());
+    thetaPID.reset(getRotation().getRadians());
   }
 
   /**
@@ -316,6 +316,24 @@ public class Drivetrain extends SubsystemBase {
    */
   public Pose2d getPose() {
     return poseEstimator.getEstimatedPosition();
+  }
+
+  /**
+   * Get the rotation of the drivetrain. This method currently just uses the navX
+   * yaw, but this is subject to change.
+   * 
+   * @return Rotation of drivetrain
+   */
+  public Rotation2d getRotation() {
+    return navX.getRotation2d();
+  }
+
+  /**
+   * Reset the rotation of the drivetrain to zero. This method currently just
+   * resets the navX yaw, but this is subject to change.
+   */
+  public void resetRotation() {
+    navX.reset();
   }
 
   /**


### PR DESCRIPTION
pose estimation has seen about zero testing and having accurate rotation is extremely important to driving a swerve so we can't risk the rotation getting thrown off by an untuned pose estimator. Methods were created to make it as easy as possible to switch back to using pose estimator for rotation.

even with a well tuned pose estimator we might not want to switch to it for rotation-only stuff though, since the navx2 should have very little drift in 2.5 minutes. the pose estimator will still be used for x,y stuff but in case of something like a camera failure or beelink powerloss we can still drive. 