### PR TITLE
reverse functionality of trigger in Drive command

### DIFF
--- a/src/main/java/frc/robot/commands/Drive.java
+++ b/src/main/java/frc/robot/commands/Drive.java
@@ -39,7 +39,7 @@ public class Drive extends CommandBase {
   DoubleSupplier xAxis;
   DoubleSupplier yAxis;
   DoubleSupplier rotationAxis;
-  DoubleSupplier slowAxis;
+  DoubleSupplier fastAxis;
 
   Trigger northTrigger;
   Trigger eastTrigger;
@@ -61,7 +61,7 @@ public class Drive extends CommandBase {
       DoubleSupplier xAxis,
       DoubleSupplier yAxis,
       DoubleSupplier rotationAxis,
-      DoubleSupplier slowAxis,
+      DoubleSupplier fastAxis,
       Trigger northTrigger,
       Trigger eastTrigger,
       Trigger southTrigger,
@@ -73,7 +73,7 @@ public class Drive extends CommandBase {
     this.xAxis = xAxis;
     this.yAxis = yAxis;
     this.rotationAxis = rotationAxis;
-    this.slowAxis = slowAxis;
+    this.fastAxis = fastAxis;
     this.northTrigger = northTrigger;
     this.eastTrigger = eastTrigger;
     this.southTrigger = southTrigger;
@@ -99,7 +99,7 @@ public class Drive extends CommandBase {
     xVelocity = xAxis.getAsDouble() * Units.feetToMeters(prefDrivetrain.driveSpeed.getValue());
     yVelocity = -yAxis.getAsDouble() * Units.feetToMeters(prefDrivetrain.driveSpeed.getValue());
     rVelocity = -rotationAxis.getAsDouble() * Units.degreesToRadians(prefDrivetrain.turnSpeed.getValue());
-    translationScalar = SN_Math.interpolate(slowAxis.getAsDouble(), 0, 1, 1, prefDrivetrain.triggerValue.getValue());
+    translationScalar = SN_Math.interpolate(fastAxis.getAsDouble(), 0, 1, prefDrivetrain.triggerValue.getValue(), 1);
 
     // scale down the translation velocity from the driver input
     translationVelocity = new Translation2d(xVelocity, yVelocity).times(translationScalar);


### PR DESCRIPTION
old functionality was that the full drive speed was mapped to the full range of the drive joystick, and the trigger provided a way to slow down the drive speed, acting as a sort of brake pedal. the issue with this in my mind is that now you have two ways to control the speed of the drivetrain: reducing the magnitude of the drive joystick input, and increasing the joystick input.

the functionality in this pr only maps a limited drive speed to the drive joystick, and the trigger can increase that speed to full speed. this is nice because because in situations where slow and accurate driving is needed (scoring or intaking) only the translation joystick needs to be used, the trigger can be released, which reducing mental strain while controlling in these tight situations. then for fast driving the trigger can be eased on and off for precise drive speed control, without sacrificing directional control.

this is mostly driver preference and what they're used to, so this might need to be reverted