### PR TITLE
completely delete color sensor

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -253,15 +253,6 @@ public final class Constants {
     public static final NeutralMode NEUTRAL_MODE = NeutralMode.Brake;
 
     public static final boolean LIMIT_SWITCH_INVERTED = true;
-
-    // RGB game piece colors
-    public static final double CONE_COLOR_R = 0.34509;
-    public static final double CONE_COLOR_G = 0.51764;
-    public static final double CONE_COLOR_B = 0.13333;
-
-    public static final double CUBE_COLOR_R = 0.22745;
-    public static final double CUBE_COLOR_G = 0.39607;
-    public static final double CUBE_COLOR_B = 0.37254;
   }
 
   public static final class constCollector {

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -1,7 +1,5 @@
 package frc.robot;
 
-import edu.wpi.first.wpilibj.I2C;
-
 public class RobotMap {
 
   // order of subsystems (and adjacent classes) shall be:
@@ -47,7 +45,6 @@ public class RobotMap {
   }
 
   public static final class mapIntake {
-    public static final I2C.Port COLOR_SENSOR_I2C = I2C.Port.kMXP;
     public static final int INTAKE_LEFT_MOTOR_CAN = 20;
     public static final int INTAKE_RIGHT_MOTOR_CAN = 21;
     public static final int INTAKE_LIMIT_SWITCH_DIO = 4;

--- a/src/main/java/frc/robot/RobotPreferences.java
+++ b/src/main/java/frc/robot/RobotPreferences.java
@@ -208,11 +208,6 @@ public class RobotPreferences {
   }
 
   public static final class prefIntake {
-    public static final SN_DoublePreference colorMatcherConfidence = new SN_DoublePreference("colorMatcherConfidence",
-        0.95);
-    // TODO: Find what proximity is needed for the sensor
-    public static final SN_DoublePreference gamePieceProximity = new SN_DoublePreference("gamePieceProximity", 100);
-
     public static final SN_DoublePreference intakeLeftMotorMultiplier = new SN_DoublePreference(
         "intakeLeftMotorMultiplier", 1.3);
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -7,18 +7,13 @@ package frc.robot.subsystems;
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.frcteam3255.components.motors.SN_CANSparkMax;
 import com.frcteam3255.preferences.SN_DoublePreference;
-import com.revrobotics.ColorMatch;
-import com.revrobotics.ColorMatchResult;
-import com.revrobotics.ColorSensorV3;
 
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Constants.constIntake;
-import frc.robot.Constants.constVision.GamePiece;
 import frc.robot.RobotMap.mapIntake;
 import frc.robot.RobotPreferences.prefIntake;
 
@@ -26,24 +21,11 @@ public class Intake extends SubsystemBase {
 
   SN_CANSparkMax leftMotor;
   SN_CANSparkMax rightMotor;
-  // ColorSensorV3 colorSensor;
-  ColorMatch colorMatcher;
-  Color coneColor;
-  Color cubeColor;
   DigitalInput limitSwitch;
 
   public Intake() {
     leftMotor = new SN_CANSparkMax(mapIntake.INTAKE_LEFT_MOTOR_CAN);
     rightMotor = new SN_CANSparkMax(mapIntake.INTAKE_RIGHT_MOTOR_CAN);
-
-    // colorSensor = new ColorSensorV3(mapIntake.COLOR_SENSOR_I2C);
-    colorMatcher = new ColorMatch();
-
-    coneColor = new Color(constIntake.CONE_COLOR_R, constIntake.CONE_COLOR_G, constIntake.CONE_COLOR_B);
-    cubeColor = new Color(constIntake.CUBE_COLOR_R, constIntake.CUBE_COLOR_G, constIntake.CUBE_COLOR_B);
-
-    colorMatcher.addColorMatch(coneColor);
-    colorMatcher.addColorMatch(cubeColor);
 
     limitSwitch = new DigitalInput(mapIntake.INTAKE_LIMIT_SWITCH_DIO);
 
@@ -59,44 +41,14 @@ public class Intake extends SubsystemBase {
 
     leftMotor.setNeutralMode(constIntake.NEUTRAL_MODE);
     rightMotor.setNeutralMode(constIntake.NEUTRAL_MODE);
-
-    colorMatcher.setConfidenceThreshold(prefIntake.colorMatcherConfidence.getValue());
   }
-
-  // public GamePiece getGamePieceType() {
-  // ColorMatchResult currentColor =
-  // colorMatcher.matchColor(colorSensor.getColor());
-
-  // if (currentColor == null) {
-  // return GamePiece.NONE;
-  // } else if (currentColor.color == coneColor) {
-  // return GamePiece.CONE;
-  // } else if (currentColor.color == cubeColor) {
-  // return GamePiece.CUBE;
-  // }
-
-  // return GamePiece.HUH;
-  // }
 
   public boolean getLimitSwitch() {
     return constIntake.LIMIT_SWITCH_INVERTED ? !limitSwitch.get() : limitSwitch.get();
   }
 
   public boolean isGamePieceCollected() {
-    if (getLimitSwitch()) {
-      return true;
-    }
-
-    // else if (colorSensor.getProximity() != 0
-    // && colorSensor.getProximity() <= prefIntake.gamePieceProximity.getValue()) {
-    // return true;
-    // }
-
-    // else if (getGamePieceType() == GamePiece.CONE || getGamePieceType() ==
-    // GamePiece.CUBE) {
-    // return true;
-    // }
-    return false;
+    return getLimitSwitch();
   }
 
   public void setMotorSpeed(SN_DoublePreference speed) {
@@ -124,20 +76,10 @@ public class Intake extends SubsystemBase {
   @Override
   public void periodic() {
 
-    // SmartDashboard.putString("Current Game Piece",
-    // getGamePieceType().toString());
     SmartDashboard.putBoolean("Intake Is Game Piece Collected", isGamePieceCollected());
 
     if (Constants.OUTPUT_DEBUG_VALUES) {
       SmartDashboard.putBoolean("Intake Limit Switch", getLimitSwitch());
-      // SmartDashboard.putString("Intake Color Sensor Color",
-      // colorSensor.getColor().toHexString());
-      // SmartDashboard.putNumber("Intake Color Sensor Red", colorSensor.getRed());
-      // SmartDashboard.putNumber("Intake Color Sensor Green",
-      // colorSensor.getGreen());
-      // SmartDashboard.putNumber("Intake Color Sensor Blue", colorSensor.getBlue());
-      // SmartDashboard.putNumber("Intake Color Sensor Proximity",
-      // colorSensor.getProximity());
     }
   }
 }


### PR DESCRIPTION
some real testing should be done but if what @TaylerUva said is correct, the robot bricks when the color sensor is unplugged. if we actually want to use a color sensor we should implement it in such a way where that doesn't happen.

the color sensor was completely unused and almost entirely commented out at phr due to this issue and the fact that we don't need one.