### PR TITLE
rename dock command to engage

### DIFF
--- a/src/main/java/frc/robot/commands/Engage.java
+++ b/src/main/java/frc/robot/commands/Engage.java
@@ -11,11 +11,11 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.RobotPreferences.prefDrivetrain;
 import frc.robot.subsystems.Drivetrain;
 
-public class Dock extends CommandBase {
+public class Engage extends CommandBase {
 
   Drivetrain subDrivetrain;
 
-  public Dock(Drivetrain subDrivetrain) {
+  public Engage(Drivetrain subDrivetrain) {
     this.subDrivetrain = subDrivetrain;
 
     addRequirements(subDrivetrain);


### PR DESCRIPTION
non functional change just renames the unused dock command to engage to better reflect what the intended (non) functionality of the command is