### PR TITLE
removed (nonfunctional) drivetrain snapping prevention while shoulder is up

### DIFF
--- a/src/main/java/frc/robot/commands/Drive.java
+++ b/src/main/java/frc/robot/commands/Drive.java
@@ -135,16 +135,6 @@ public class Drive extends CommandBase {
 
     }
 
-    // if the shoulder is at -90 just remember the current rotation position
-    if (subArm.getGoalShoulderAngle().getDegrees() == -90 && subArm.isShoulderInTolerance()) {
-      lastRotationPosition = rotationPosition;
-    }
-    // if the shoulder isn't at -90 override the button press and just go to the
-    // last valid rotation position
-    else {
-      rotationPosition = lastRotationPosition;
-    }
-
     // if the driver isn't using the rotation joystick and also pressed a rotation
     // button, use driveAlignAngle for positional rotation control
     if (isRotationPositional) {


### PR DESCRIPTION
this never worked correctly and the implementation was very flawed. I think it probably caused more issues than it solved.